### PR TITLE
Add editorconfig and reformat gitignore

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = spaces
+
+[*.{c,h,cpp,hpp}]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-.DS_Store
-build/
-.vs/
-out/
+# IDE files/folders
 .vscode/
+.vs/
+
+# Build
+[Oo]ut/
+[Bb]uild/
+
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 
 # Configuration file
 configure_file(${CMAKE_SOURCE_DIR}/src/cmake.hpp.in cmake.hpp)
+configure_file(${CMAKE_SOURCE_DIR}/.editorconfig .editorconfig COPYONLY)
 
 # Add your sources to the target
 file( GLOB_RECURSE SOURCE_FILES src/* )


### PR DESCRIPTION
A .editorconfig file allows many editors (e.g. Visual Studio Code)to autoconfigure themselves based on its contents. This avoids some formatting issues in PRs because editors will do the right thing by default with a .editorconfig file available in the repo.