### PR TITLE
Add clang-format and clang-tidy for better formatting and basic linting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+﻿BasedOnStyle: llvm

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,67 @@
+---
+Checks: >
+  -*,
+  bugprone-assert-side-effect,
+  bugprone-assignment-in-if-condition,
+  bugprone-bool-pointer-implicit-conversion,
+  bugprone-dangling-handle,
+  bugprone-dynamic-static-initializers,
+  bugprone-infinite-loop,
+  bugprone-integer-division,
+  bugprone-macro-repeated-side-effects,
+  bugprone-misplaced-operator-in-strlen-in-alloc,
+  bugprone-misplaced-pointer-arithmetic-in-alloc,
+  bugprone-misplaced-widening-cast,
+  bugprone-not-null-terminated-result,
+  bugprone-posix-return,
+  bugprone-redundant-branch-condition,
+  bugprone-string-literal-with-embedded-nul,
+  bugprone-suspicious-memset-usage,
+  bugprone-suspicious-semicolon,
+  bugprone-suspicious-string-compare,
+  bugprone-too-small-loop-variable,
+  bugprone-unused-return-value,
+  cert-err33-c,
+  clang-analyzer-core.*,
+  clang-analyzer-valist.*,
+  clang-analyzer-unix.Malloc,
+  clang-diagnostic-*,
+  google-readability-casting,
+  misc-misleading-bidirectional,
+  misc-misleading-identifier,
+  misc-misplaced-const,
+  misc-redundant-expression,
+  objc-*,
+  performance-type-promotion-in-math-fn,
+  readability-avoid-const-params-in-decls,
+  readability-braces-around-statements,
+  readability-const-return-type,
+  readability-duplicate-include,
+  readability-inconsistent-declaration-parameter-name,
+  readability-misplaced-array-index,
+  readability-non-const-parameter,
+  readability-redundant-control-flow,
+  readability-redundant-declaration,
+  readability-redundant-function-ptr-dereference,
+  readability-redundant-preprocessor,
+  '-*,readability-identifier-naming',
+  readability-simplify-boolean-expr
+  
+CheckOptions:
+  - key:   bugprone-assert-side-effect.AssertMacros
+    value: "SDL_assert, SDL_assert_release, SDL_assert_paranoid, SDL_assert_always, SDL_COMPILE_TIME_ASSERT"
+  - key:   bugprone-misplaced-widening-cast.CheckImplicitCasts
+    value: true
+  - key:   bugprone-not-null-terminated-result.WantToUseSafeFunctions
+    value: false # Do not recommend _s functions
+  - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,           value: PascalCase  }
+  - { key: readability-identifier-naming.PrivateMemberPrefix, value: m_         }
+  - { key: readability-identifier-naming.StructCase,          value: PascalCase  }
+  - { key: readability-identifier-naming.FunctionCase,        value: CamelCase }
+  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
+  - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
+
+FormatStyle: "file"
+HeaderFilterRegex: "*.h$"
+WarningsAsErrors: ""


### PR DESCRIPTION
## Description
This PR introduces clang-format and clang-tidy to the project to enforce consistent code formatting and perform basic static analysis. These tools will help maintain a clean and readable codebase by automatically formatting code according to predefined rules and identifying potential issues early in the development process.

## Changes
    Added .clang-format configuration file to define coding style rules.
    Added .clang-tidy configuration file to enable basic linting checks.

## Tests
    Verified that clang-format correctly formats the code in Visual Studio
    Ensured that clang-tidy runs as part of the build process and reports any issues.